### PR TITLE
fix: mark vendored JS to fix GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/pdf.worker.min.mjs linguist-vendored


### PR DESCRIPTION
## Summary

- Add `.gitattributes` marking `public/pdf.worker.min.mjs` as `linguist-vendored`
- This 1.9 MB pdfjs-dist worker file was causing GitHub to report 84.9% JavaScript instead of TypeScript as the primary language

## Test plan

- [ ] After merge, verify repo language stats on GitHub show TypeScript as primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)