### PR TITLE
refactor: rename CV Builder to Resume Builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CV Builder
+# Resume Builder
 
-A CV/Resume builder built with React, TypeScript, and TanStack Router. Supports multiple templates, dark mode, i18n (PL/EN), PDF export/import, and PWA with offline support.
+A resume builder built with React, TypeScript, and TanStack Router. Supports multiple templates, dark mode, i18n (PL/EN), PDF export/import, and PWA with offline support.
 
 **Every new feature MUST be documented in this file.**
 
@@ -254,7 +254,7 @@ Page transitions rely on CSS entrance animations — no View Transition API (dis
 - **Head management**: TanStack Router `head()` property + `<HeadContent />` in root layout
 - **Constants**: `/src/lib/seo.ts` — `SITE_URL` (from `VITE_SITE_URL` env var), `SEO_DEFAULTS`, `OG_DEFAULTS`, `TEMPLATE_NAMES`
 - **Per-route titles**: Each route defines `head()` with unique `title`, `og:title`, `twitter:title`, and `canonical` link
-- **Title convention**: `Page Name | CV Builder` (child routes), `CV Builder - Create Professional Resumes in Minutes` (home)
+- **Title convention**: `Page Name | Resume Builder` (child routes), `Resume Builder - Create Professional Resumes in Minutes` (home)
 - **Static fallbacks**: `index.html` contains static meta/OG/Twitter tags for crawlers that don't execute JS
 - **JSON-LD**: Schema.org `WebApplication` structured data in root route `head()` via `script:ld+json`
 - **Open Graph image**: `/public/og-image.png` (1200x630)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ pnpm pre-commit   # Format + lint + test + tsc + build (run before every commit)
 src/
 ├── components/
 │   ├── ui/                # Base UI components (shadcn/ui style)
-│   ├── form-sections/     # CV form section components
+│   ├── form-sections/     # Resume form section components
 │   │   ├── personal-info-section.tsx
 │   │   ├── experience-section.tsx
 │   │   ├── education-section.tsx
@@ -48,23 +48,23 @@ src/
 │   │   ├── languages-section.tsx
 │   │   ├── interests-section.tsx
 │   │   └── gdpr-consent-section.tsx
-│   ├── templates/         # CV render templates (developer, default, veterinary)
+│   ├── templates/         # Resume render templates (developer, default, veterinary)
 │   ├── template-previews/ # Template preview cards
 │   ├── pwa-reload-prompt.tsx   # SW update notification
 │   ├── pwa-install-prompt.tsx  # Browser install prompt
 │   └── offline-indicator.tsx   # Offline status banner
 ├── contexts/              # React Context providers (theme)
-├── data/                  # Sample data, type interfaces for CV data
+├── data/                  # Sample data, type interfaces for resume data
 ├── hooks/                 # Custom hooks (use-theme)
 ├── lib/                   # Utilities (pdf-parser, helpers)
 ├── locales/               # i18n translations (en/, pl/)
 ├── pages/                 # Page components
 │   ├── builder-page.tsx   # Main form builder
-│   ├── preview-page.tsx   # CV preview + PDF export
+│   ├── preview-page.tsx   # Resume preview + PDF export
 │   ├── templates-page.tsx # Template gallery
 │   └── template-page.tsx  # Single template preview
 ├── routes/                # TanStack Router route definitions
-├── schemas/               # Zod validation schemas (cv-schema)
+├── schemas/               # Zod validation schemas (resume-schema)
 └── types/                 # TypeScript types (form-types, form-component-types, theme)
 ```
 
@@ -75,8 +75,8 @@ src/
 | `/`                      | Home page                   |
 | `/templates`             | Template selection gallery  |
 | `/templates/:templateId` | Individual template preview |
-| `/builder`               | CV form builder             |
-| `/preview`               | CV preview with PDF export  |
+| `/builder`               | Resume form builder         |
+| `/preview`               | Resume preview + PDF export |
 
 ## Tech Stack
 
@@ -136,7 +136,7 @@ src/
 
 ### Data Flow
 
-- Form data stored in localStorage under key `cvData` (+ `cvData_backup`)
+- Form data stored in localStorage under key `resumeData` (+ `resumeData_backup`)
 - Auto-save every 30 seconds, manual save button available
 - Template selection passed via URL query param `?templateId=`
 
@@ -159,8 +159,8 @@ Types defined in `/src/types/form-types.ts`:
 
 ### Validation
 
-- Centralized Zod schemas in `/src/schemas/cv-schema.ts` — single source of truth
-- Wired into TanStack Form via `validators: { onChange: cvFormSchema }`
+- Centralized Zod schemas in `/src/schemas/resume-schema.ts` — single source of truth
+- Wired into TanStack Form via `validators: { onChange: resumeFormSchema }`
 - Field errors exposed via `field.state.meta.errors` and rendered inline using `<FieldError>` component (`/src/components/ui/field-error.tsx`)
 - Error messages are i18n keys (e.g., `validation.firstNameRequired`) translated at render time
 - Errors display only after field is touched (`isTouched` check)
@@ -172,7 +172,7 @@ Types defined in `/src/types/form-types.ts`:
 
 Form section components accept a `FormApi` type from `/src/types/form-component-types.ts`. This file uses ESLint-disabled `any` internally for TanStack Form flexibility.
 
-## CV Templates
+## Resume Templates
 
 Three templates, each in `/src/components/templates/`:
 
@@ -186,7 +186,7 @@ Google Fonts are imported in `/src/index.css`. Atkinson Hyperlegible is used for
 
 ### Critical Template Rules
 
-- **CV templates MUST always have white background** — dark mode only affects surrounding UI
+- **Resume templates MUST always have white background** — dark mode only affects surrounding UI
 - **All templates must be print-optimized** with proper page breaks
 - **Language proficiency** uses European framework: A1, A2, B1, B2, C1, C2, NATIVE
 - **New sections** added to one template must be added to all three
@@ -215,7 +215,7 @@ The PDF parser (`/src/lib/pdf-parser.ts`) detects templates by section markers:
 
 ## GDPR Consent Clause
 
-- Toggle in builder form enables/disables the clause on the CV
+- Toggle in builder form enables/disables the clause on the resume
 - With company name: uses `cv.gdprConsent` translation (mentions company by name)
 - Without company name: uses `cv.gdprConsentGeneric` translation (generic clause)
 - Rendered at the bottom of all three templates when enabled
@@ -235,7 +235,7 @@ Page transitions rely on CSS entrance animations — no View Transition API (dis
 - **Micro-interactions**: `.hover-lift` class for button/card hover (scale + shadow)
 - **Accessibility**: All animations disabled when `prefers-reduced-motion: reduce` is set
 - **Browser support**: Modern browsers. Animations gracefully degrade with `prefers-reduced-motion`.
-- CV templates are NOT animated — they stay print-clean with white backgrounds
+- Resume templates are NOT animated — they stay print-clean with white backgrounds
 
 ### Scroll-linked Parallax & whileInView
 
@@ -282,7 +282,7 @@ All three are mounted in `root-layout.tsx` alongside `<PrivacyNotice />`. UI fol
 
 ## PDF Import
 
-- Uses `pdfjs-dist` to extract CV data from PDF metadata (Keywords field)
+- Uses `pdfjs-dist` to extract resume data from PDF metadata (Keywords field)
 - Falls back to raw text parsing if no metadata found
 - Only works reliably with PDFs generated by this application
 - Entry point: "Load PDF" button in builder page header

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to CV Builder
+# Contributing to Resume Builder
 
 ## Prerequisites
 
@@ -9,8 +9,8 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/Kris1027/cv-builder.git
-cd cv-builder
+git clone https://github.com/Kris1027/resume-builder.git
+cd resume-builder
 
 # Install dependencies
 pnpm install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# CV Builder
+# Resume Builder
 
-A modern, intuitive CV/Resume builder with multiple templates, dark mode, i18n, and PDF export.
+A modern, intuitive resume builder with multiple templates, dark mode, i18n, and PDF export.
 
 [![React][React-badge]][React-url]
 [![TypeScript][TypeScript-badge]][TypeScript-url]
@@ -87,8 +87,8 @@ A modern, intuitive CV/Resume builder with multiple templates, dark mode, i18n, 
 ### Installation
 
 ```bash
-git clone https://github.com/Kris1027/cv-builder.git
-cd cv-builder
+git clone https://github.com/Kris1027/resume-builder.git
+cd resume-builder
 pnpm install
 pnpm dev
 ```
@@ -164,7 +164,7 @@ This project is provided for viewing and reference purposes only. No permission 
 
 ## Support
 
-For issues, questions, or suggestions, please [open an issue on GitHub](https://github.com/Kris1027/cv-builder/issues).
+For issues, questions, or suggestions, please [open an issue on GitHub](https://github.com/Kris1027/resume-builder/issues).
 
 <!-- Tech Badges -->
 

--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
         <meta name="theme-color" content="#ffffff" />
 
         <!-- Static fallback for crawlers that don't execute JS -->
-        <title>CV Builder - Create Professional Resumes in Minutes</title>
+        <title>Resume Builder - Create Professional Resumes in Minutes</title>
         <meta
             name="description"
-            content="Create professional resumes with our free CV builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
+            content="Create professional resumes with our free resume builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
         />
         <meta
             name="keywords"
@@ -18,25 +18,31 @@
 
         <!-- Open Graph (static fallback) -->
         <meta property="og:type" content="website" />
-        <meta property="og:site_name" content="CV Builder" />
-        <meta property="og:title" content="CV Builder - Create Professional Resumes in Minutes" />
+        <meta property="og:site_name" content="Resume Builder" />
+        <meta
+            property="og:title"
+            content="Resume Builder - Create Professional Resumes in Minutes"
+        />
         <meta
             property="og:description"
-            content="Create professional resumes with our free CV builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
+            content="Create professional resumes with our free resume builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
         />
-        <meta property="og:url" content="https://cv-builder.app" />
-        <meta property="og:image" content="https://cv-builder.app/og-image.png" />
+        <meta property="og:url" content="https://resume-builder.techkris.eu" />
+        <meta property="og:image" content="https://resume-builder.techkris.eu/og-image.png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
 
         <!-- Twitter Card (static fallback) -->
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="CV Builder - Create Professional Resumes in Minutes" />
+        <meta
+            name="twitter:title"
+            content="Resume Builder - Create Professional Resumes in Minutes"
+        />
         <meta
             name="twitter:description"
-            content="Create professional resumes with our free CV builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
+            content="Create professional resumes with our free resume builder. Choose from multiple templates, customize your layout, and export to PDF in minutes."
         />
-        <meta name="twitter:image" content="https://cv-builder.app/og-image.png" />
+        <meta name="twitter:image" content="https://resume-builder.techkris.eu/og-image.png" />
 
         <!-- Preload critical fonts -->
         <link

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "cv-builder",
+    "name": "resume-builder",
     "private": true,
     "version": "0.0.0",
-    "description": "A modern CV/Resume builder with multiple templates, dark mode, i18n, and PDF export",
+    "description": "A modern resume builder with multiple templates, dark mode, i18n, and PDF export",
     "author": "Kris1027",
     "license": "SEE LICENSE IN LICENSE",
     "repository": {
         "type": "git",
-        "url": "https://github.com/Kris1027/cv-builder.git"
+        "url": "https://github.com/Kris1027/resume-builder.git"
     },
-    "homepage": "https://github.com/Kris1027/cv-builder",
+    "homepage": "https://github.com/Kris1027/resume-builder",
     "bugs": {
-        "url": "https://github.com/Kris1027/cv-builder/issues"
+        "url": "https://github.com/Kris1027/resume-builder/issues"
     },
     "keywords": [
         "cv",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://cv-builder.app/sitemap.xml
+Sitemap: https://resume-builder.techkris.eu/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://cv-builder.app/</loc>
+    <loc>https://resume-builder.techkris.eu/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://cv-builder.app/templates</loc>
+    <loc>https://resume-builder.techkris.eu/templates</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://cv-builder.app/templates/developer</loc>
+    <loc>https://resume-builder.techkris.eu/templates/developer</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://cv-builder.app/templates/default</loc>
+    <loc>https://resume-builder.techkris.eu/templates/default</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://cv-builder.app/templates/veterinary</loc>
+    <loc>https://resume-builder.techkris.eu/templates/veterinary</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://cv-builder.app/builder</loc>
+    <loc>https://resume-builder.techkris.eu/builder</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/src/components/pwa-install-prompt.test.tsx
+++ b/src/components/pwa-install-prompt.test.tsx
@@ -33,7 +33,7 @@ describe('PwaInstallPrompt', () => {
 
         expect(screen.getByRole('button', { name: 'Install app' })).toBeInTheDocument();
         expect(
-            screen.getByText('Install CV Builder for quick access and offline use'),
+            screen.getByText('Install Resume Builder for quick access and offline use'),
         ).toBeInTheDocument();
     });
 

--- a/src/components/template-previews/default-preview.tsx
+++ b/src/components/template-previews/default-preview.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { DefaultTemplate } from '@/components/templates/default-template';
-import { sampleDefaultCVData } from '@/data/sample-cv-data';
-import { sampleDefaultCVDataPl } from '@/data/sample-cv-data-pl';
+import { sampleDefaultResumeData } from '@/data/sample-resume-data';
+import { sampleDefaultResumeDataPl } from '@/data/sample-resume-data-pl';
 import { TemplateCardPreview } from './template-card-preview';
 
 export const DefaultPreview = () => {
@@ -10,7 +10,9 @@ export const DefaultPreview = () => {
 
     return (
         <TemplateCardPreview>
-            <DefaultTemplate data={isPolish ? sampleDefaultCVDataPl : sampleDefaultCVData} />
+            <DefaultTemplate
+                data={isPolish ? sampleDefaultResumeDataPl : sampleDefaultResumeData}
+            />
         </TemplateCardPreview>
     );
 };

--- a/src/components/template-previews/developer-preview.tsx
+++ b/src/components/template-previews/developer-preview.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { DeveloperTemplate } from '@/components/templates/developer-template';
-import { sampleCVData } from '@/data/sample-cv-data';
-import { sampleCVDataPl } from '@/data/sample-cv-data-pl';
+import { sampleResumeData } from '@/data/sample-resume-data';
+import { sampleResumeDataPl } from '@/data/sample-resume-data-pl';
 import { TemplateCardPreview } from './template-card-preview';
 
 export const DeveloperPreview = () => {
@@ -10,7 +10,7 @@ export const DeveloperPreview = () => {
 
     return (
         <TemplateCardPreview>
-            <DeveloperTemplate data={isPolish ? sampleCVDataPl : sampleCVData} />
+            <DeveloperTemplate data={isPolish ? sampleResumeDataPl : sampleResumeData} />
         </TemplateCardPreview>
     );
 };

--- a/src/components/template-previews/veterinary-preview.tsx
+++ b/src/components/template-previews/veterinary-preview.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { VeterinaryTemplate } from '@/components/templates/veterinary-template';
-import { sampleVeterinaryCVData } from '@/data/sample-cv-data';
-import { sampleVeterinaryCVDataPl } from '@/data/sample-cv-data-pl';
+import { sampleVeterinaryResumeData } from '@/data/sample-resume-data';
+import { sampleVeterinaryResumeDataPl } from '@/data/sample-resume-data-pl';
 import { TemplateCardPreview } from './template-card-preview';
 
 export const VeterinaryPreview = () => {
@@ -11,7 +11,7 @@ export const VeterinaryPreview = () => {
     return (
         <TemplateCardPreview>
             <VeterinaryTemplate
-                data={isPolish ? sampleVeterinaryCVDataPl : sampleVeterinaryCVData}
+                data={isPolish ? sampleVeterinaryResumeDataPl : sampleVeterinaryResumeData}
             />
         </TemplateCardPreview>
     );

--- a/src/components/templates/default-template.tsx
+++ b/src/components/templates/default-template.tsx
@@ -1,4 +1,4 @@
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 import { Mail, Phone, Globe, MapPin } from 'lucide-react';
 import { formatLinkedinDisplay } from '@/lib/utils';
 import { DescriptionList } from '@/components/description-list';
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { formatCVDateShort, formatCVYear } from '@/lib/date-utils';
 
 interface DefaultTemplateProps {
-    data: CVData;
+    data: ResumeData;
 }
 
 export function DefaultTemplate({ data }: DefaultTemplateProps) {

--- a/src/components/templates/developer-template.tsx
+++ b/src/components/templates/developer-template.tsx
@@ -1,4 +1,4 @@
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 import { Mail, Phone, Globe, MapPin, Github, Linkedin } from 'lucide-react';
 import { formatWebsiteDisplay, formatGithubDisplay, formatLinkedinDisplay } from '@/lib/utils';
 import { DescriptionList } from '@/components/description-list';
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { formatCVDate, formatCVYear } from '@/lib/date-utils';
 
 interface DeveloperTemplateProps {
-    data: CVData;
+    data: ResumeData;
 }
 
 export function DeveloperTemplate({ data }: DeveloperTemplateProps) {

--- a/src/components/templates/veterinary-template.tsx
+++ b/src/components/templates/veterinary-template.tsx
@@ -1,4 +1,4 @@
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 import { Mail, Phone, Globe, MapPin, Stethoscope, Award, Heart, Briefcase } from 'lucide-react';
 import { formatLinkedinDisplay } from '@/lib/utils';
 import { DescriptionList } from '@/components/description-list';
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { formatCVDateShort, formatCVYear } from '@/lib/date-utils';
 
 interface VeterinaryTemplateProps {
-    data: CVData;
+    data: ResumeData;
 }
 
 export function VeterinaryTemplate({ data }: VeterinaryTemplateProps) {

--- a/src/data/sample-resume-data-pl.ts
+++ b/src/data/sample-resume-data-pl.ts
@@ -1,7 +1,7 @@
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 
 // Developer-focused sample data (for Developer template) - Polish version
-export const sampleCVDataPl: CVData = {
+export const sampleResumeDataPl: ResumeData = {
     personalInfo: {
         firstName: 'Michał',
         lastName: 'Nowak',
@@ -89,7 +89,7 @@ export const sampleCVDataPl: CVData = {
 };
 
 // Generic professional sample data (for Default template) - Polish version
-export const sampleDefaultCVDataPl: CVData = {
+export const sampleDefaultResumeDataPl: ResumeData = {
     personalInfo: {
         firstName: 'Anna',
         lastName: 'Wiśniewska',
@@ -182,7 +182,7 @@ export const sampleDefaultCVDataPl: CVData = {
 };
 
 // Veterinary professional sample data (for Veterinary template) - Polish version
-export const sampleVeterinaryCVDataPl: CVData = {
+export const sampleVeterinaryResumeDataPl: ResumeData = {
     personalInfo: {
         firstName: 'Katarzyna',
         lastName: 'Kowalska',

--- a/src/data/sample-resume-data.ts
+++ b/src/data/sample-resume-data.ts
@@ -1,7 +1,7 @@
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 
 // Developer-focused sample data (for Developer template)
-export const sampleCVData: CVData = {
+export const sampleResumeData: ResumeData = {
     personalInfo: {
         firstName: 'John',
         lastName: 'Anderson',
@@ -89,7 +89,7 @@ export const sampleCVData: CVData = {
 };
 
 // Generic professional sample data (for Default template)
-export const sampleDefaultCVData: CVData = {
+export const sampleDefaultResumeData: ResumeData = {
     personalInfo: {
         firstName: 'Sarah',
         lastName: 'Mitchell',
@@ -181,7 +181,7 @@ export const sampleDefaultCVData: CVData = {
 };
 
 // Veterinary professional sample data (for Veterinary template)
-export const sampleVeterinaryCVData: CVData = {
+export const sampleVeterinaryResumeData: ResumeData = {
     personalInfo: {
         firstName: 'Emily',
         lastName: 'Roberts',

--- a/src/lib/pdf-export.test.ts
+++ b/src/lib/pdf-export.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { generateCVFilename } from './pdf-export';
+import { generateResumeFilename } from './pdf-export';
 
-describe('generateCVFilename', () => {
+describe('generateResumeFilename', () => {
     it('builds filename from first and last name', () => {
-        expect(generateCVFilename('John', 'Doe')).toBe('John-Doe-CV.pdf');
+        expect(generateResumeFilename('John', 'Doe')).toBe('John-Doe-Resume.pdf');
     });
 
     it('uses only first name when last name is missing', () => {
-        expect(generateCVFilename('John')).toBe('John-CV.pdf');
+        expect(generateResumeFilename('John')).toBe('John-Resume.pdf');
     });
 
     it('uses only last name when first name is missing', () => {
-        expect(generateCVFilename(undefined, 'Doe')).toBe('Doe-CV.pdf');
+        expect(generateResumeFilename(undefined, 'Doe')).toBe('Doe-Resume.pdf');
     });
 
     it('falls back to "my" when no names provided', () => {
-        expect(generateCVFilename()).toBe('my-CV.pdf');
+        expect(generateResumeFilename()).toBe('my-Resume.pdf');
     });
 
     it('falls back to "my" when names are empty strings', () => {
-        expect(generateCVFilename('', '')).toBe('my-CV.pdf');
+        expect(generateResumeFilename('', '')).toBe('my-Resume.pdf');
     });
 });

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -312,7 +312,7 @@ export async function exportToPDF(
         pdf.setProperties({
             title: filename.replace('.pdf', ''),
             subject: 'CV/Resume',
-            creator: 'CV Builder App',
+            creator: 'Resume Builder App',
             keywords: cvData, // Store JSON data in keywords field
         });
     }

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -20,7 +20,7 @@ export interface PDFExportOptions {
     filename?: string;
     scale?: number;
     singlePage?: boolean;
-    cvData?: string; // JSON string of CV data to embed in PDF
+    resumeData?: string; // JSON string of resume data to embed in PDF
     imageQuality?: number; // JPEG quality 0-1 (default 0.92)
     compression?: 'NONE' | 'FAST' | 'MEDIUM' | 'SLOW'; // Image compression level (default 'MEDIUM')
 }
@@ -146,7 +146,7 @@ export async function exportToPDF(
         filename = 'cv.pdf',
         scale = 2,
         singlePage = false,
-        cvData,
+        resumeData,
         imageQuality = 0.92, // High quality JPEG (significantly reduces file size compared to PNG)
         compression = 'MEDIUM', // jsPDF compression level
     } = options;
@@ -307,13 +307,13 @@ export async function exportToPDF(
         }
     });
 
-    // Embed CV data as custom metadata if provided
-    if (cvData) {
+    // Embed resume data as custom metadata if provided
+    if (resumeData) {
         pdf.setProperties({
             title: filename.replace('.pdf', ''),
-            subject: 'CV/Resume',
+            subject: 'Resume',
             creator: 'Resume Builder App',
-            keywords: cvData, // Store JSON data in keywords field
+            keywords: resumeData, // Store JSON data in keywords field
         });
     }
 
@@ -321,8 +321,8 @@ export async function exportToPDF(
     pdf.save(filename);
 }
 
-export function generateCVFilename(firstName?: string, lastName?: string): string {
+export function generateResumeFilename(firstName?: string, lastName?: string): string {
     const nameParts = [firstName, lastName].filter(Boolean);
     const name = nameParts.length > 0 ? nameParts.join('-') : 'my';
-    return `${name}-CV.pdf`;
+    return `${name}-Resume.pdf`;
 }

--- a/src/lib/pdf-parser.test.ts
+++ b/src/lib/pdf-parser.test.ts
@@ -6,7 +6,7 @@ vi.mock('pdfjs-dist', () => ({
     getDocument: vi.fn(),
 }));
 
-import { detectTemplate, parseCVFromText } from './pdf-parser';
+import { detectTemplate, parseResumeFromText } from './pdf-parser';
 
 describe('detectTemplate', () => {
     it('detects developer template by // WORK EXPERIENCE', () => {
@@ -34,7 +34,7 @@ describe('detectTemplate', () => {
     });
 });
 
-describe('parseCVFromText — developer template', () => {
+describe('parseResumeFromText — developer template', () => {
     const developerText = [
         'John Doe',
         'Senior Developer',
@@ -59,19 +59,19 @@ describe('parseCVFromText — developer template', () => {
     ].join('\n');
 
     it('parses personal info', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         expect(result.personalInfo.firstName).toBe('John');
         expect(result.personalInfo.lastName).toBe('Doe');
         expect(result.personalInfo.email).toBe('john@example.com');
     });
 
     it('sets templateId to developer', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         expect(result.templateId).toBe('developer');
     });
 
     it('parses experiences', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         expect(result.experiences.length).toBeGreaterThanOrEqual(1);
         expect(result.experiences[0].company).toBe('ACME Corp');
         expect(result.experiences[0].position).toBe('Frontend Developer');
@@ -79,27 +79,27 @@ describe('parseCVFromText — developer template', () => {
     });
 
     it('parses skills from TECH STACK', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         const skillNames = result.skills.map((s) => s.name);
         expect(skillNames).toContain('TypeScript');
         expect(skillNames).toContain('React');
     });
 
     it('parses languages with proficiency', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         expect(result.languages.length).toBeGreaterThanOrEqual(1);
         const polish = result.languages.find((l) => l.language === 'Polish');
         expect(polish?.proficiency).toBe('NATIVE');
     });
 
     it('parses interests', () => {
-        const result = parseCVFromText(developerText, 'developer');
+        const result = parseResumeFromText(developerText, 'developer');
         const interestNames = result.interests.map((i) => i.name);
         expect(interestNames).toContain('Hiking');
     });
 });
 
-describe('parseCVFromText — default template', () => {
+describe('parseResumeFromText — default template', () => {
     const defaultText = [
         'Jane Smith',
         'Product Manager',
@@ -120,24 +120,24 @@ describe('parseCVFromText — default template', () => {
     ].join('\n');
 
     it('parses with templateId default', () => {
-        const result = parseCVFromText(defaultText, 'default');
+        const result = parseResumeFromText(defaultText, 'default');
         expect(result.templateId).toBe('default');
     });
 
     it('parses personal info', () => {
-        const result = parseCVFromText(defaultText, 'default');
+        const result = parseResumeFromText(defaultText, 'default');
         expect(result.personalInfo.firstName).toBe('Jane');
         expect(result.personalInfo.lastName).toBe('Smith');
     });
 
     it('parses Core Competencies as skills', () => {
-        const result = parseCVFromText(defaultText, 'default');
+        const result = parseResumeFromText(defaultText, 'default');
         const skillNames = result.skills.map((s) => s.name);
         expect(skillNames).toContain('Leadership');
     });
 });
 
-describe('parseCVFromText — veterinary template', () => {
+describe('parseResumeFromText — veterinary template', () => {
     const vetText = [
         'Anna Kowalska',
         'Veterinarian',
@@ -158,18 +158,18 @@ describe('parseCVFromText — veterinary template', () => {
     ].join('\n');
 
     it('parses with templateId veterinary', () => {
-        const result = parseCVFromText(vetText, 'veterinary');
+        const result = parseResumeFromText(vetText, 'veterinary');
         expect(result.templateId).toBe('veterinary');
     });
 
     it('parses personal info', () => {
-        const result = parseCVFromText(vetText, 'veterinary');
+        const result = parseResumeFromText(vetText, 'veterinary');
         expect(result.personalInfo.firstName).toBe('Anna');
         expect(result.personalInfo.lastName).toBe('Kowalska');
     });
 
     it('parses skills section', () => {
-        const result = parseCVFromText(vetText, 'veterinary');
+        const result = parseResumeFromText(vetText, 'veterinary');
         const skillNames = result.skills.map((s) => s.name);
         expect(skillNames).toContain('Surgery');
     });

--- a/src/lib/pdf-parser.ts
+++ b/src/lib/pdf-parser.ts
@@ -1,4 +1,4 @@
-import type { CVFormValues, LanguageLevelProps } from '@/types/form-types';
+import type { ResumeFormValues, LanguageLevelProps } from '@/types/form-types';
 import type { TemplateId } from '@/lib/template-ids';
 import i18n from '@/i18n/config';
 
@@ -55,9 +55,9 @@ export function detectTemplate(text: string): TemplateId {
 }
 
 /**
- * Parse CV data from extracted PDF text
+ * Parse resume data from extracted PDF text
  */
-export function parseCVFromText(text: string, templateId: TemplateId): CVFormValues {
+export function parseResumeFromText(text: string, templateId: TemplateId): ResumeFormValues {
     const lines = text
         .split(/\n|\s{2,}/)
         .map((l) => l.trim())
@@ -77,8 +77,8 @@ export function parseCVFromText(text: string, templateId: TemplateId): CVFormVal
 /**
  * Parse the Developer template format
  */
-function parseDeveloperTemplate(lines: string[]): CVFormValues {
-    const result = createEmptyCV('developer');
+function parseDeveloperTemplate(lines: string[]): ResumeFormValues {
+    const result = createEmptyResume('developer');
 
     // Find section markers
     const workExpIndex = lines.findIndex((l) => l.includes('// WORK EXPERIENCE'));
@@ -145,8 +145,8 @@ function parseDeveloperTemplate(lines: string[]): CVFormValues {
 /**
  * Parse the Default template format
  */
-function parseDefaultTemplate(lines: string[]): CVFormValues {
-    const result = createEmptyCV('default');
+function parseDefaultTemplate(lines: string[]): ResumeFormValues {
+    const result = createEmptyResume('default');
 
     // Find section markers (uppercase headers)
     const profExpIndex = lines.findIndex(
@@ -217,8 +217,8 @@ function parseDefaultTemplate(lines: string[]): CVFormValues {
 /**
  * Parse the Veterinary template format
  */
-function parseVeterinaryTemplate(lines: string[]): CVFormValues {
-    const result = createEmptyCV('veterinary');
+function parseVeterinaryTemplate(lines: string[]): ResumeFormValues {
+    const result = createEmptyResume('veterinary');
 
     // Find section markers
     const workExpIndex = lines.findIndex((l) => l.includes('Work Experience'));
@@ -289,8 +289,8 @@ function parseVeterinaryTemplate(lines: string[]): CVFormValues {
 /**
  * Parse header/contact information
  */
-function parseHeaderInfo(lines: string[]): CVFormValues['personalInfo'] {
-    const info: CVFormValues['personalInfo'] = {
+function parseHeaderInfo(lines: string[]): ResumeFormValues['personalInfo'] {
+    const info: ResumeFormValues['personalInfo'] = {
         firstName: '',
         lastName: '',
         location: '',
@@ -384,9 +384,9 @@ function parseHeaderInfo(lines: string[]): CVFormValues['personalInfo'] {
 /**
  * Parse work experience entries
  */
-function parseExperiences(lines: string[]): CVFormValues['experiences'] {
-    const experiences: CVFormValues['experiences'] = [];
-    let currentExp: CVFormValues['experiences'][0] | null = null;
+function parseExperiences(lines: string[]): ResumeFormValues['experiences'] {
+    const experiences: ResumeFormValues['experiences'] = [];
+    let currentExp: ResumeFormValues['experiences'][0] | null = null;
     let descriptionLines: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
@@ -453,9 +453,9 @@ function parseExperiences(lines: string[]): CVFormValues['experiences'] {
 /**
  * Parse education entries
  */
-function parseEducation(lines: string[]): CVFormValues['education'] {
-    const education: CVFormValues['education'] = [];
-    let currentEdu: CVFormValues['education'][0] | null = null;
+function parseEducation(lines: string[]): ResumeFormValues['education'] {
+    const education: ResumeFormValues['education'] = [];
+    let currentEdu: ResumeFormValues['education'][0] | null = null;
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -526,8 +526,8 @@ function parseEducation(lines: string[]): CVFormValues['education'] {
 /**
  * Parse skills from skill tags/list
  */
-function parseSkills(lines: string[]): CVFormValues['skills'] {
-    const skills: CVFormValues['skills'] = [];
+function parseSkills(lines: string[]): ResumeFormValues['skills'] {
+    const skills: ResumeFormValues['skills'] = [];
     const seenSkills = new Set<string>();
 
     for (const line of lines) {
@@ -553,8 +553,8 @@ function parseSkills(lines: string[]): CVFormValues['skills'] {
 /**
  * Parse language entries with proficiency
  */
-function parseLanguages(lines: string[]): CVFormValues['languages'] {
-    const languages: CVFormValues['languages'] = [];
+function parseLanguages(lines: string[]): ResumeFormValues['languages'] {
+    const languages: ResumeFormValues['languages'] = [];
     const validProficiencies: LanguageLevelProps[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'NATIVE'];
 
     for (const line of lines) {
@@ -594,8 +594,8 @@ function parseLanguages(lines: string[]): CVFormValues['languages'] {
 /**
  * Parse interests from tags/list
  */
-function parseInterests(lines: string[]): CVFormValues['interests'] {
-    const interests: CVFormValues['interests'] = [];
+function parseInterests(lines: string[]): ResumeFormValues['interests'] {
+    const interests: ResumeFormValues['interests'] = [];
     const seenInterests = new Set<string>();
 
     for (const line of lines) {
@@ -619,7 +619,7 @@ function parseInterests(lines: string[]): CVFormValues['interests'] {
 
 // Helper functions
 
-function createEmptyCV(templateId: TemplateId): CVFormValues {
+function createEmptyResume(templateId: TemplateId): ResumeFormValues {
     return {
         templateId,
         personalInfo: {
@@ -721,20 +721,20 @@ function isCommonWord(word: string): boolean {
 }
 
 /**
- * Extract CV data from PDF metadata (keywords field)
+ * Extract resume data from PDF metadata (keywords field)
  */
-export async function extractCVDataFromMetadata(file: File): Promise<CVFormValues | null> {
+export async function extractResumeDataFromMetadata(file: File): Promise<ResumeFormValues | null> {
     const pdfjsLib = await getPdfjs();
     const arrayBuffer = await file.arrayBuffer();
     const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
     const metadata = await pdf.getMetadata();
 
-    // Check if CV data is stored in keywords
+    // Check if resume data is stored in keywords
     const info = metadata?.info as Record<string, unknown> | undefined;
     if (info?.Keywords && typeof info.Keywords === 'string') {
         try {
-            const cvData = JSON.parse(info.Keywords);
-            return cvData as CVFormValues;
+            const resumeData = JSON.parse(info.Keywords);
+            return resumeData as ResumeFormValues;
         } catch {
             // Keywords is not valid JSON
         }
@@ -744,15 +744,15 @@ export async function extractCVDataFromMetadata(file: File): Promise<CVFormValue
 }
 
 /**
- * Main function to load CV from PDF file
+ * Main function to load resume from PDF file
  * Only works with PDFs created by this app (with embedded metadata)
  */
-export async function loadCVFromPDF(file: File): Promise<CVFormValues> {
-    const metadataResult = await extractCVDataFromMetadata(file);
+export async function loadResumeFromPDF(file: File): Promise<ResumeFormValues> {
+    const metadataResult = await extractResumeDataFromMetadata(file);
     if (metadataResult) {
         return metadataResult;
     }
 
-    // PDF doesn't have embedded CV data - not created by this app
+    // PDF doesn't have embedded resume data - not created by this app
     throw new Error(i18n.t('dialogs.pdfError.notFromApp'));
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -10,11 +10,11 @@ if (!import.meta.env.VITE_SITE_URL) {
 export const SITE_URL = import.meta.env.VITE_SITE_URL;
 
 export const SEO_DEFAULTS = {
-    siteName: 'CV Builder',
+    siteName: 'Resume Builder',
     description:
-        'Create professional resumes with our free CV builder. Choose from multiple templates, customize your layout, and export to PDF in minutes.',
+        'Create professional resumes with our free resume builder. Choose from multiple templates, customize your layout, and export to PDF in minutes.',
     keywords:
-        'cv builder, resume builder, free cv maker, professional resume, pdf resume, cv templates, resume templates',
+        'resume builder, cv builder, free resume maker, professional resume, pdf resume, cv templates, resume templates',
 } as const;
 
 export const OG_DEFAULTS = {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -244,7 +244,7 @@
         "pdfError": {
             "title": "Unable to Load PDF",
             "ok": "OK",
-            "notFromApp": "This PDF was not created by CV Builder. Only PDFs exported from this application can be loaded. You can fill out the form manually instead.",
+            "notFromApp": "This PDF was not created by Resume Builder. Only PDFs exported from this application can be loaded. You can fill out the form manually instead.",
             "unexpected": "An unexpected error occurred while loading the PDF."
         }
     },
@@ -353,7 +353,7 @@
         "reload": "Reload",
         "close": "Close",
         "install": "Install app",
-        "installDescription": "Install CV Builder for quick access and offline use",
+        "installDescription": "Install Resume Builder for quick access and offline use",
         "offline": "You're offline — all features still work"
     }
 }

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -244,7 +244,7 @@
         "pdfError": {
             "title": "Nie można wczytać PDF",
             "ok": "OK",
-            "notFromApp": "Ten plik PDF nie został utworzony przez CV Builder. Można wczytać jedynie pliki PDF wyeksportowane z tej aplikacji. Możesz zamiast tego wypełnić formularz ręcznie.",
+            "notFromApp": "Ten plik PDF nie został utworzony przez Resume Builder. Można wczytać jedynie pliki PDF wyeksportowane z tej aplikacji. Możesz zamiast tego wypełnić formularz ręcznie.",
             "unexpected": "Wystąpił nieoczekiwany błąd podczas wczytywania pliku PDF."
         }
     },
@@ -353,7 +353,7 @@
         "reload": "Odśwież",
         "close": "Zamknij",
         "install": "Zainstaluj aplikację",
-        "installDescription": "Zainstaluj CV Builder, aby mieć szybki dostęp i możliwość pracy offline",
+        "installDescription": "Zainstaluj Resume Builder, aby mieć szybki dostęp i możliwość pracy offline",
         "offline": "Jesteś offline — wszystkie funkcje nadal działają"
     }
 }

--- a/src/pages/builder-page.tsx
+++ b/src/pages/builder-page.tsx
@@ -9,7 +9,7 @@ import { GdprConsentSection } from '@/components/form-sections/gdpr-consent-sect
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LanguageToggle } from '@/components/language-toggle';
 import type {
-    CVFormValues,
+    ResumeFormValues,
     EducationProps,
     ExperienceProps,
     InterestProps,
@@ -19,7 +19,7 @@ import type {
     SkillProps,
 } from '@/types/form-types';
 import { useForm } from '@tanstack/react-form';
-import { cvFormSchema } from '@/schemas/cv-schema';
+import { resumeFormSchema } from '@/schemas/resume-schema';
 import {
     ArrowLeft,
     CheckCircle,
@@ -41,7 +41,7 @@ import {
     AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { useState, useRef, useEffect } from 'react';
-import { loadCVFromPDF } from '@/lib/pdf-parser';
+import { loadResumeFromPDF } from '@/lib/pdf-parser';
 import { useNavigate, Link, useSearch } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { motion, useReducedMotion } from 'motion/react';
@@ -109,14 +109,14 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
 
     // Get initial values - load from localStorage if available, otherwise defaults
     const getInitialValues = () => {
-        const storedData = safeStorage.getItem('cvData');
+        const storedData = safeStorage.getItem('resumeData');
         if (storedData) {
             let parsedData;
             try {
                 parsedData = JSON.parse(storedData);
             } catch {
                 if (import.meta.env.DEV)
-                    console.warn('Failed to parse stored CV data, starting fresh');
+                    console.warn('Failed to parse stored resume data, starting fresh');
                 return {
                     templateId: activeTemplateId,
                     personalInfo: emptyPersonalInfo as PersonalInfoProps,
@@ -161,15 +161,15 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
     const form = useForm({
         defaultValues: getInitialValues(),
         validators: {
-            onChange: cvFormSchema,
+            onChange: resumeFormSchema,
         },
         onSubmit: async ({ value }) => {
             setIsSaving(true);
             // Store data in localStorage for persistence
             const json = JSON.stringify(value);
-            const ok = safeStorage.setItem('cvData', json);
+            const ok = safeStorage.setItem('resumeData', json);
             const now = new Date();
-            safeStorage.setItem('cvData_lastSaved', now.toISOString());
+            safeStorage.setItem('resumeData_lastSaved', now.toISOString());
             lastSavedJsonRef.current = json;
             setSaveError(!ok);
             setIsAutoSaved(false);
@@ -194,13 +194,13 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
     // Auto-save every 30 seconds
     useEffect(() => {
         const interval = setInterval(() => {
-            const formData = form.state.values as CVFormValues;
+            const formData = form.state.values as ResumeFormValues;
             const json = JSON.stringify(formData);
             if (json === lastSavedJsonRef.current) return;
 
-            const ok = safeStorage.setItem('cvData', json);
+            const ok = safeStorage.setItem('resumeData', json);
             const now = new Date();
-            safeStorage.setItem('cvData_lastSaved', now.toISOString());
+            safeStorage.setItem('resumeData_lastSaved', now.toISOString());
             lastSavedJsonRef.current = json;
             setSaveError(!ok);
             setIsAutoSaved(true);
@@ -213,12 +213,12 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
     // Manual save function
     const handleManualSave = () => {
         setIsSaving(true);
-        const formData = form.state.values as CVFormValues;
+        const formData = form.state.values as ResumeFormValues;
         const json = JSON.stringify(formData);
-        const ok = safeStorage.setItem('cvData', json);
-        safeStorage.setItem('cvData_backup', json);
+        const ok = safeStorage.setItem('resumeData', json);
+        safeStorage.setItem('resumeData_backup', json);
         const now = new Date();
-        safeStorage.setItem('cvData_lastSaved', now.toISOString());
+        safeStorage.setItem('resumeData_lastSaved', now.toISOString());
         lastSavedJsonRef.current = json;
         setSaveError(!ok);
         setIsAutoSaved(false);
@@ -228,8 +228,8 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
 
     // Reset form function — keeps backup intact for recovery
     const handleReset = () => {
-        safeStorage.removeItem('cvData');
-        safeStorage.removeItem('cvData_lastSaved');
+        safeStorage.removeItem('resumeData');
+        safeStorage.removeItem('resumeData_lastSaved');
         setLastSaved(null);
         form.reset({
             templateId: activeTemplateId,
@@ -257,30 +257,30 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
 
         setIsLoadingPDF(true);
         try {
-            const cvData = await loadCVFromPDF(file);
+            const resumeData = await loadResumeFromPDF(file);
 
             // Normalize PDF data by merging with defaults to backfill missing keys
-            const normalizedPersonalInfo = { ...emptyPersonalInfo, ...cvData.personalInfo };
-            const normalizedGdprConsent = { ...emptyGdprConsent, ...cvData.gdprConsent };
+            const normalizedPersonalInfo = { ...emptyPersonalInfo, ...resumeData.personalInfo };
+            const normalizedGdprConsent = { ...emptyGdprConsent, ...resumeData.gdprConsent };
 
             // Build the complete new form values
-            // PDF metadata (CVData) doesn't include templateId — fall back to
+            // PDF metadata (ResumeData) doesn't include templateId — fall back to
             // the currently active template so form.reset() gets a valid string
             // and the Zod schema doesn't trigger a "fix errors" validation message.
             const newValues = {
-                templateId: cvData.templateId || activeTemplateId,
+                templateId: resumeData.templateId || activeTemplateId,
                 personalInfo: normalizedPersonalInfo,
-                experiences: cvData.experiences ?? [],
-                education: cvData.education ?? [],
-                skills: cvData.skills ?? [],
-                languages: cvData.languages ?? [],
-                interests: cvData.interests ?? [],
+                experiences: resumeData.experiences ?? [],
+                education: resumeData.education ?? [],
+                skills: resumeData.skills ?? [],
+                languages: resumeData.languages ?? [],
+                interests: resumeData.interests ?? [],
                 gdprConsent: normalizedGdprConsent,
             };
 
             // Persist first so getInitialValues() returns matching data on
             // re-render, preventing useForm's update() from overwriting the reset
-            safeStorage.setItem('cvData', JSON.stringify(newValues));
+            safeStorage.setItem('resumeData', JSON.stringify(newValues));
 
             // Reset the form with all values at once — no intermediate
             // validation states and no stale errors
@@ -428,7 +428,7 @@ const BuilderPage = ({ templateId = 'developer' }: BuilderPageProps) => {
 
     // Calculate form progress
     const calculateProgress = () => {
-        const values = form.state.values as CVFormValues;
+        const values = form.state.values as ResumeFormValues;
         let progress = 0;
 
         // Personal info (30%)

--- a/src/pages/preview-page.tsx
+++ b/src/pages/preview-page.tsx
@@ -5,7 +5,7 @@ import { DeveloperTemplate } from '@/components/templates/developer-template';
 import { DefaultTemplate } from '@/components/templates/default-template';
 import { VeterinaryTemplate } from '@/components/templates/veterinary-template';
 import { ScaleToFitContainer } from '@/components/scale-to-fit-container';
-import type { CVData } from '@/types/form-types';
+import type { ResumeData } from '@/types/form-types';
 import {
     ArrowLeft,
     Download,
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LanguageToggle } from '@/components/language-toggle';
-import { exportToPDF, generateCVFilename } from '@/lib/pdf-export';
+import { exportToPDF, generateResumeFilename } from '@/lib/pdf-export';
 import { useTranslation } from 'react-i18next';
 import { motion, useReducedMotion } from 'motion/react';
 import { useParallax } from '@/hooks/use-parallax';
@@ -46,7 +46,7 @@ export const PreviewPage = () => {
     const bgDots = useParallax({ yRange: 15 });
     const bgShapes = useParallax({ yRange: 40 });
 
-    const [cvData, setCvData] = useState<CVData | null>(null);
+    const [resumeData, setResumeData] = useState<ResumeData | null>(null);
     const [isExporting, setIsExporting] = useState(false);
     const [exportError, setExportError] = useState<string | null>(null);
     const [singlePageMode, setSinglePageMode] = useState(false);
@@ -61,17 +61,17 @@ export const PreviewPage = () => {
 
     useEffect(() => {
         // Get data from localStorage
-        const storedData = safeStorage.getItem('cvData');
+        const storedData = safeStorage.getItem('resumeData');
         if (storedData) {
             let parsedData;
             try {
                 parsedData = JSON.parse(storedData);
             } catch {
-                if (import.meta.env.DEV) console.warn('Failed to parse stored CV data');
+                if (import.meta.env.DEV) console.warn('Failed to parse stored resume data');
                 return;
             }
             // Ensure all arrays have default values
-            const transformedData: CVData = {
+            const transformedData: ResumeData = {
                 personalInfo: parsedData.personalInfo,
                 experiences: parsedData.experiences || [],
                 education: parsedData.education || [],
@@ -80,13 +80,13 @@ export const PreviewPage = () => {
                 interests: parsedData.interests || [],
                 gdprConsent: parsedData.gdprConsent,
             };
-            setCvData(transformedData);
+            setResumeData(transformedData);
         }
     }, []);
 
     const handleDownloadPDF = async () => {
         const element = document.getElementById('cv-content');
-        if (!element || !cvData) return;
+        if (!element || !resumeData) return;
 
         setIsExporting(true);
 
@@ -117,14 +117,14 @@ export const PreviewPage = () => {
             // Temporarily disable CSS transform scaling for accurate capture
             disableScaling();
 
-            const filename = generateCVFilename(
-                cvData.personalInfo?.firstName,
-                cvData.personalInfo?.lastName,
+            const filename = generateResumeFilename(
+                resumeData.personalInfo?.firstName,
+                resumeData.personalInfo?.lastName,
             );
             await exportToPDF(element, {
                 filename,
                 singlePage: singlePageMode,
-                cvData: JSON.stringify(cvData),
+                resumeData: JSON.stringify(resumeData),
             });
         } catch (error) {
             if (import.meta.env.DEV) console.error('Failed to export PDF:', error);
@@ -135,7 +135,7 @@ export const PreviewPage = () => {
         }
     };
 
-    if (!cvData) {
+    if (!resumeData) {
         return (
             <div className='relative min-h-screen overflow-hidden'>
                 {/* Background gradient mesh */}
@@ -354,10 +354,12 @@ export const PreviewPage = () => {
                                 className='overflow-hidden bg-white text-gray-900 shadow-xl'
                                 {...fadeInScale(0.1, shouldReduceMotion)}
                             >
-                                {templateId === 'developer' && <DeveloperTemplate data={cvData} />}
-                                {templateId === 'default' && <DefaultTemplate data={cvData} />}
+                                {templateId === 'developer' && (
+                                    <DeveloperTemplate data={resumeData} />
+                                )}
+                                {templateId === 'default' && <DefaultTemplate data={resumeData} />}
                                 {templateId === 'veterinary' && (
-                                    <VeterinaryTemplate data={cvData} />
+                                    <VeterinaryTemplate data={resumeData} />
                                 )}
                             </motion.div>
                         </ScaleToFitContainer>

--- a/src/pages/template-page.tsx
+++ b/src/pages/template-page.tsx
@@ -3,12 +3,16 @@ import { Button } from '@/components/ui/button';
 import { DeveloperTemplate } from '@/components/templates/developer-template';
 import { DefaultTemplate } from '@/components/templates/default-template';
 import { VeterinaryTemplate } from '@/components/templates/veterinary-template';
-import { sampleCVData, sampleDefaultCVData, sampleVeterinaryCVData } from '@/data/sample-cv-data';
 import {
-    sampleCVDataPl,
-    sampleDefaultCVDataPl,
-    sampleVeterinaryCVDataPl,
-} from '@/data/sample-cv-data-pl';
+    sampleResumeData,
+    sampleDefaultResumeData,
+    sampleVeterinaryResumeData,
+} from '@/data/sample-resume-data';
+import {
+    sampleResumeDataPl,
+    sampleDefaultResumeDataPl,
+    sampleVeterinaryResumeDataPl,
+} from '@/data/sample-resume-data-pl';
 import { ArrowLeft, Edit } from 'lucide-react';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { LanguageToggle } from '@/components/language-toggle';
@@ -44,17 +48,19 @@ export function TemplatePage() {
     const renderTemplate = () => {
         switch (templateId) {
             case 'developer':
-                return <DeveloperTemplate data={isPolish ? sampleCVDataPl : sampleCVData} />;
+                return (
+                    <DeveloperTemplate data={isPolish ? sampleResumeDataPl : sampleResumeData} />
+                );
             case 'default':
                 return (
                     <DefaultTemplate
-                        data={isPolish ? sampleDefaultCVDataPl : sampleDefaultCVData}
+                        data={isPolish ? sampleDefaultResumeDataPl : sampleDefaultResumeData}
                     />
                 );
             case 'veterinary':
                 return (
                     <VeterinaryTemplate
-                        data={isPolish ? sampleVeterinaryCVDataPl : sampleVeterinaryCVData}
+                        data={isPolish ? sampleVeterinaryResumeDataPl : sampleVeterinaryResumeData}
                     />
                 );
             default:

--- a/src/pages/templates-page.tsx
+++ b/src/pages/templates-page.tsx
@@ -73,8 +73,8 @@ export const TemplatesPage = () => {
     const bgShapes = useParallax({ yRange: 40 });
 
     useEffect(() => {
-        const savedData = safeStorage.getItem('cvData');
-        const savedTime = safeStorage.getItem('cvData_lastSaved');
+        const savedData = safeStorage.getItem('resumeData');
+        const savedTime = safeStorage.getItem('resumeData_lastSaved');
 
         if (savedData) {
             setHasSavedData(true);
@@ -85,9 +85,9 @@ export const TemplatesPage = () => {
     }, []);
 
     const handleReset = () => {
-        safeStorage.removeItem('cvData');
-        safeStorage.removeItem('cvData_backup');
-        safeStorage.removeItem('cvData_lastSaved');
+        safeStorage.removeItem('resumeData');
+        safeStorage.removeItem('resumeData_backup');
+        safeStorage.removeItem('resumeData_lastSaved');
         setHasSavedData(false);
         setLastSaved(null);
     };

--- a/src/schemas/resume-schema.test.ts
+++ b/src/schemas/resume-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { cvFormSchema } from './cv-schema';
+import { resumeFormSchema } from './resume-schema';
 
 const validForm = {
     templateId: 'developer',
@@ -42,9 +42,9 @@ const validForm = {
     gdprConsent: { enabled: true, companyName: 'ACME Corp' },
 };
 
-describe('cvFormSchema', () => {
+describe('resumeFormSchema', () => {
     it('accepts a fully valid form', () => {
-        const result = cvFormSchema.safeParse(validForm);
+        const result = resumeFormSchema.safeParse(validForm);
         expect(result.success).toBe(true);
     });
 
@@ -54,7 +54,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, firstName: '' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
             if (!result.success) {
                 const messages = result.error.issues.map((i) => i.message);
@@ -67,7 +67,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, lastName: '' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
             if (!result.success) {
                 const messages = result.error.issues.map((i) => i.message);
@@ -80,7 +80,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, email: '' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
             if (!result.success) {
                 const messages = result.error.issues.map((i) => i.message);
@@ -95,7 +95,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, email: 'not-an-email' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
             if (!result.success) {
                 const messages = result.error.issues.map((i) => i.message);
@@ -108,7 +108,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, email: 'test@domain.com' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(true);
         });
     });
@@ -127,7 +127,7 @@ describe('cvFormSchema', () => {
                     github: '',
                 },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(true);
         });
     });
@@ -140,7 +140,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 languages: [{ language: 'Test', proficiency: level }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(true);
         });
 
@@ -149,7 +149,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 languages: [{ language: 'Test', proficiency: 'X9' }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
     });
@@ -160,7 +160,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 gdprConsent: { enabled: false, companyName: '' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(true);
         });
 
@@ -169,7 +169,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 gdprConsent: { enabled: 'yes', companyName: '' },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
     });
@@ -180,7 +180,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, firstName: 'a'.repeat(101) },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
             if (!result.success) {
                 const messages = result.error.issues.map((i) => i.message);
@@ -193,7 +193,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, lastName: 'a'.repeat(101) },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -205,7 +205,7 @@ describe('cvFormSchema', () => {
                     email: 'a'.repeat(243) + '@example.com',
                 },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -214,7 +214,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, phone: '1'.repeat(31) },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -223,7 +223,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 personalInfo: { ...validForm.personalInfo, website: 'a'.repeat(201) },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -232,7 +232,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 experiences: [{ ...validForm.experiences[0], description: 'a'.repeat(2001) }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -241,7 +241,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 skills: [{ name: 'a'.repeat(101) }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -250,7 +250,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 languages: [{ language: 'a'.repeat(101), proficiency: 'C2' as const }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -259,7 +259,7 @@ describe('cvFormSchema', () => {
                 ...validForm,
                 gdprConsent: { enabled: true, companyName: 'a'.repeat(201) },
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(false);
         });
 
@@ -274,7 +274,7 @@ describe('cvFormSchema', () => {
                 },
                 skills: [{ name: 'a'.repeat(100) }],
             };
-            const result = cvFormSchema.safeParse(data);
+            const result = resumeFormSchema.safeParse(data);
             expect(result.success).toBe(true);
         });
     });
@@ -289,7 +289,7 @@ describe('cvFormSchema', () => {
                 email: '',
             },
         };
-        const result = cvFormSchema.safeParse(data);
+        const result = resumeFormSchema.safeParse(data);
         expect(result.success).toBe(false);
         if (!result.success) {
             expect(result.error.issues.length).toBeGreaterThanOrEqual(3);

--- a/src/schemas/resume-schema.ts
+++ b/src/schemas/resume-schema.ts
@@ -56,7 +56,7 @@ const gdprConsentSchema = z.object({
     companyName: z.string().max(200, 'validation.maxLength'),
 });
 
-export const cvFormSchema = z.object({
+export const resumeFormSchema = z.object({
     templateId: z.enum(TEMPLATE_IDS),
     personalInfo: personalInfoSchema,
     experiences: z.array(experienceSchema),
@@ -67,4 +67,4 @@ export const cvFormSchema = z.object({
     gdprConsent: gdprConsentSchema,
 });
 
-export type CVFormValues = z.infer<typeof cvFormSchema>;
+export type ResumeFormValues = z.infer<typeof resumeFormSchema>;

--- a/src/types/form-types.ts
+++ b/src/types/form-types.ts
@@ -49,8 +49,8 @@ export interface GdprConsentProps {
     companyName: string;
 }
 
-// CVData used by sample data and templates (gdprConsent is optional)
-export type CVData = {
+// ResumeData used by sample data and templates (gdprConsent is optional)
+export type ResumeData = {
     personalInfo: PersonalInfoProps;
     experiences: ExperienceProps[];
     education: EducationProps[];
@@ -61,4 +61,4 @@ export type CVData = {
 };
 
 // Form values inferred from Zod schema — single source of truth
-export type { CVFormValues } from '@/schemas/cv-schema';
+export type { ResumeFormValues } from '@/schemas/resume-schema';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,8 +50,8 @@ export default defineConfig(({ command }) => ({
                 'apple-touch-icon.png',
             ],
             manifest: {
-                name: 'CV Builder - Create Professional Resumes',
-                short_name: 'CV Builder',
+                name: 'Resume Builder - Create Professional Resumes',
+                short_name: 'Resume Builder',
                 description: 'Create professional resumes with multiple templates and PDF export',
                 theme_color: '#a7f3d0',
                 background_color: '#ffffff',


### PR DESCRIPTION
## Summary
- Rename all user-facing text, metadata, and SEO references from "CV Builder" to "Resume Builder" (commit 1)
- Rename all internal code identifiers — filenames, types, variables, localStorage keys, and function names — from `cv`/`CV` to `resume`/`Resume` (commit 2)
- PDF output filename changed from `name-CV.pdf` to `name-Resume.pdf`
- localStorage keys renamed without backward compatibility (`cvData` → `resumeData`)
- Template detection markers in PDF parser left unchanged (they match rendered PDF text)

## Test plan
- [x] `pnpm pre-commit` passes (format + lint + 113 tests + tsc + build)
- [ ] Verify templates render correctly with sample data
- [ ] Verify PDF export produces `name-Resume.pdf` filename
- [ ] Verify localStorage uses `resumeData` key
- [ ] Verify PDF import still works with app-generated PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)