### PR TITLE
refactor: rename remaining CV references to Resume

### DIFF
--- a/src/components/privacy-notice.test.tsx
+++ b/src/components/privacy-notice.test.tsx
@@ -14,7 +14,7 @@ describe('PrivacyNotice', () => {
         expect(screen.getByText('Your data stays private')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'All your CV data is stored locally in your browser. Nothing is sent to any server.',
+                'All your resume data is stored locally in your browser. Nothing is sent to any server.',
             ),
         ).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Got it' })).toBeInTheDocument();

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -219,8 +219,8 @@
         },
         "gdprConsent": {
             "title": "GDPR Consent Clause",
-            "description": "Add a GDPR data processing consent clause to the bottom of your CV",
-            "enable": "Include GDPR consent clause in CV",
+            "description": "Add a GDPR data processing consent clause to the bottom of your resume",
+            "enable": "Include GDPR consent clause in resume",
             "companyName": "Company name",
             "companyNamePlaceholder": "Enter company name",
             "companyNameHint": "Leave empty for a generic clause without a company name"
@@ -236,8 +236,8 @@
     },
     "dialogs": {
         "reset": {
-            "title": "Reset CV Data",
-            "description": "Are you sure you want to reset all your CV data? Your last manual save will be kept as a backup.",
+            "title": "Reset Resume Data",
+            "description": "Are you sure you want to reset all your resume data? Your last manual save will be kept as a backup.",
             "cancel": "Cancel",
             "confirm": "Reset All Data"
         },
@@ -249,22 +249,22 @@
         }
     },
     "preview": {
-        "title": "Your CV Preview",
-        "noData": "No CV data found",
-        "noDataHint": "Please fill out the form first to preview your CV.",
-        "startBuilding": "Start Building Your CV",
+        "title": "Your Resume Preview",
+        "noData": "No resume data found",
+        "noDataHint": "Please fill out the form first to preview your resume.",
+        "startBuilding": "Start Building Your Resume",
         "multiPage": "Multi",
         "singlePage": "Single",
         "downloadPdf": "Download PDF",
         "exporting": "Exporting...",
-        "editCv": "Edit CV",
+        "editCv": "Edit Resume",
         "success": {
-            "title": "Congratulations! Your CV is ready.",
+            "title": "Congratulations! Your resume is ready.",
             "subtitle": "You can now download as PDF or continue editing."
         },
         "contentWarning": {
             "title": "Content is very long",
-            "subtitle": "Your CV has been scaled to the minimum (50%). Consider reducing content for better readability."
+            "subtitle": "Your resume has been scaled to the minimum (50%). Consider reducing content for better readability."
         },
         "exportError": "Failed to export PDF. Please try again.",
         "exportErrorTitle": "Export Failed"
@@ -344,7 +344,7 @@
     },
     "privacy": {
         "notice": "Your data stays private",
-        "details": "All your CV data is stored locally in your browser. Nothing is sent to any server.",
+        "details": "All your resume data is stored locally in your browser. Nothing is sent to any server.",
         "accept": "Got it"
     },
     "pwa": {

--- a/src/pages/preview-page.tsx
+++ b/src/pages/preview-page.tsx
@@ -85,7 +85,7 @@ export const PreviewPage = () => {
     }, []);
 
     const handleDownloadPDF = async () => {
-        const element = document.getElementById('cv-content');
+        const element = document.getElementById('resume-content');
         if (!element || !resumeData) return;
 
         setIsExporting(true);
@@ -350,7 +350,7 @@ export const PreviewPage = () => {
                             className='mx-auto max-w-[210mm]'
                         >
                             <motion.div
-                                id='cv-content'
+                                id='resume-content'
                                 className='overflow-hidden bg-white text-gray-900 shadow-xl'
                                 {...fadeInScale(0.1, shouldReduceMotion)}
                             >
@@ -413,7 +413,7 @@ export const PreviewPage = () => {
           }
 
           /* Clean CV content for print */
-          #cv-content {
+          #resume-content {
             margin: 0 !important;
             padding: 0 !important;
             box-shadow: none !important;


### PR DESCRIPTION
## Summary
- Renamed leftover "CV" → "resume" in English translation strings (GDPR section, reset dialog, preview page, privacy notice)
- Renamed `cv-content` DOM ID to `resume-content` in preview page
- Updated test assertion to match new EN translation
- Polish translations intentionally keep "CV" as the standard Polish term
- GDPR legal consent text kept as "CV" in both languages (correct legal terminology)

Addresses Copilot review comments from #68.

## Test plan
- [x] `pnpm pre-commit` passes (format, lint, test, tsc, build)
- [ ] Verify EN strings show "resume" in GDPR section, reset dialog, preview page, privacy notice
- [ ] Verify PL strings still show "CV" in all sections
- [ ] Verify PDF export still works (uses `resume-content` DOM ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)