### PR TITLE
Allow blob frame sources for PDF preview CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
             "headers": [
                 {
                     "key": "Content-Security-Policy",
-                    "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+                    "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' data: blob:; frame-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
                 }
             ]
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ const contentSecurityPolicy = [
     "img-src 'self' data: blob:",
     "font-src 'self' data:",
     "connect-src 'self' data: blob:",
+    "frame-src 'self' blob:",
     "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary
- add  to the build-time CSP meta tag
- add the same  allowance to the production CSP header
- unblock blob-based PDF preview rendering inside frames

## Testing
- pnpm build