### PR TITLE
Fix PDF preview loading and initialization issues

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -927,6 +927,11 @@
 }
 
 @layer base {
+    html,
+    body {
+        position: relative;
+    }
+
     * {
         @apply border-border outline-ring/50;
     }

--- a/src/pages/preview-page.tsx
+++ b/src/pages/preview-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Link, useSearch } from '@tanstack/react-router';
 import { Button } from '@/components/ui/button';
 import type { ResumeData } from '@/types/form-types';
@@ -20,7 +20,7 @@ import {
     AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { safeStorage } from '@/lib/storage';
-import { PDFViewer } from '@react-pdf/renderer';
+import { PDFViewer, type DocumentProps } from '@react-pdf/renderer';
 import { DeveloperPDF } from '@/lib/pdf-templates/developer-pdf';
 import { DefaultPDF } from '@/lib/pdf-templates/default-pdf';
 import { VeterinaryPDF } from '@/lib/pdf-templates/veterinary-pdf';
@@ -37,6 +37,18 @@ function getPdfDocument(
         return <DefaultPDF data={resumeData} compactScale={compactScale} lang={lang} />;
     return <VeterinaryPDF data={resumeData} compactScale={compactScale} lang={lang} />;
 }
+
+const PdfPreview = memo(function PdfPreview({
+    document,
+}: {
+    document: ReactElement<DocumentProps>;
+}) {
+    return (
+        <PDFViewer width='100%' height='100%' showToolbar={false}>
+            {document}
+        </PDFViewer>
+    );
+});
 
 // Binary search: find the minimum compactScale (0–1) that makes the PDF fit on one page.
 // Returns null when content can't fit even at maximum compaction.
@@ -78,6 +90,7 @@ export const PreviewPage = () => {
     // null = searching, number = found scale, 'cannot-fit' = even max compaction overflows
     const [optimalScale, setOptimalScale] = useState<number | 'cannot-fit' | null>(null);
     const [useCompact, setUseCompact] = useState(false);
+    const [isPreviewReady, setIsPreviewReady] = useState(false);
 
     useEffect(() => {
         const storedData = safeStorage.getItem('resumeData');
@@ -107,6 +120,7 @@ export const PreviewPage = () => {
         if (!resumeData) return;
 
         // Reset all compact-related state so stale values don't linger if templateId changes
+        setIsPreviewReady(false);
         setIsMultiPage(false);
         setOptimalScale(null);
         setUseCompact(false);
@@ -120,18 +134,25 @@ export const PreviewPage = () => {
             if (cancelled) return;
 
             const pages = await countPdfPages(normalBlob);
-            if (pages <= 1) return;
+            if (pages <= 1) {
+                setIsPreviewReady(true);
+                return;
+            }
 
             setIsMultiPage(true);
 
             const scale = await findMinCompactScale((s) =>
                 pdf(getPdfDocument(resumeData!, templateId, s, lang)).toBlob(),
             );
-            if (!cancelled) setOptimalScale(scale === null ? 'cannot-fit' : scale);
+            if (!cancelled) {
+                setOptimalScale(scale === null ? 'cannot-fit' : scale);
+                setIsPreviewReady(true);
+            }
         }
 
         run().catch((err) => {
             if (import.meta.env.DEV) console.error('Failed to detect PDF page count:', err);
+            if (!cancelled) setIsPreviewReady(true);
         });
 
         return () => {
@@ -160,6 +181,14 @@ export const PreviewPage = () => {
             setIsExporting(false);
         }
     };
+
+    const activeScale = useCompact && typeof optimalScale === 'number' ? optimalScale : 0;
+    const pdfDocument = useMemo(
+        () => (resumeData ? getPdfDocument(resumeData, templateId, activeScale, lang) : null),
+        [resumeData, templateId, activeScale, lang],
+    );
+    // Hide toggle entirely when content can't fit even at max compaction
+    const showToggle = isPreviewReady && isMultiPage && optimalScale !== 'cannot-fit';
 
     if (!resumeData) {
         return (
@@ -194,12 +223,6 @@ export const PreviewPage = () => {
         );
     }
 
-    const activeScale = useCompact && typeof optimalScale === 'number' ? optimalScale : 0;
-    const pdfDocument = getPdfDocument(resumeData, templateId, activeScale, lang);
-    const isSearching = isMultiPage && optimalScale === null;
-    // Hide toggle entirely when content can't fit even at max compaction
-    const showToggle = isMultiPage && optimalScale !== 'cannot-fit';
-
     return (
         <div className='flex h-screen flex-col overflow-hidden'>
             {/* Navbar */}
@@ -219,42 +242,39 @@ export const PreviewPage = () => {
                         </div>
 
                         <div className='flex items-center gap-3'>
-                            {/* Page layout toggle — visible only when content exceeds one page and can be compacted */}
-                            {showToggle && (
-                                <div className='flex items-center overflow-hidden rounded-md border border-gray-200 dark:border-gray-700'>
-                                    <button
-                                        type='button'
-                                        aria-pressed={!useCompact}
-                                        onClick={() => setUseCompact(false)}
-                                        className={`flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
-                                            !useCompact
-                                                ? 'bg-indigo-600 text-white'
-                                                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
-                                        }`}
-                                    >
-                                        <Files className='h-3.5 w-3.5' />
-                                        {t('preview.multiPage')}
-                                    </button>
-                                    <button
-                                        type='button'
-                                        aria-pressed={useCompact}
-                                        onClick={() => setUseCompact(true)}
-                                        disabled={isSearching}
-                                        className={`flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                                            useCompact
-                                                ? 'bg-indigo-600 text-white'
-                                                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
-                                        }`}
-                                    >
-                                        {isSearching ? (
-                                            <Loader2 className='h-3.5 w-3.5 animate-spin' />
-                                        ) : (
+                            <div className='flex min-h-8 items-center justify-end md:min-w-[190px]'>
+                                {/* Page layout toggle — visible only when content exceeds one page and can be compacted */}
+                                {showToggle && (
+                                    <div className='flex items-center overflow-hidden rounded-md border border-gray-200 dark:border-gray-700'>
+                                        <button
+                                            type='button'
+                                            aria-pressed={!useCompact}
+                                            onClick={() => setUseCompact(false)}
+                                            className={`flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
+                                                !useCompact
+                                                    ? 'bg-indigo-600 text-white'
+                                                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                                            }`}
+                                        >
+                                            <Files className='h-3.5 w-3.5' />
+                                            {t('preview.multiPage')}
+                                        </button>
+                                        <button
+                                            type='button'
+                                            aria-pressed={useCompact}
+                                            onClick={() => setUseCompact(true)}
+                                            className={`flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
+                                                useCompact
+                                                    ? 'bg-indigo-600 text-white'
+                                                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                                            }`}
+                                        >
                                             <FileText className='h-3.5 w-3.5' />
-                                        )}
-                                        {t('preview.singlePage')}
-                                    </button>
-                                </div>
-                            )}
+                                            {t('preview.singlePage')}
+                                        </button>
+                                    </div>
+                                )}
+                            </div>
 
                             <Button
                                 variant='outline'
@@ -289,9 +309,15 @@ export const PreviewPage = () => {
 
             {/* PDF Preview */}
             <div className='min-h-0 flex-1'>
-                <PDFViewer width='100%' height='100%' showToolbar={false}>
-                    {pdfDocument}
-                </PDFViewer>
+                {isPreviewReady && pdfDocument ? (
+                    <PdfPreview document={pdfDocument} />
+                ) : (
+                    <div className='flex h-full items-center justify-center bg-slate-50 dark:bg-slate-950'>
+                        <p className='text-sm text-gray-500 dark:text-gray-400'>
+                            {t('preview.title')}...
+                        </p>
+                    </div>
+                )}
             </div>
 
             {/* Export Error Dialog */}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,6 +2,30 @@ import { createRootRoute } from '@tanstack/react-router';
 import { RootLayout } from '@/components/root-layout';
 import { SITE_URL, SEO_DEFAULTS, OG_DEFAULTS } from '@/lib/seo';
 
+const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: SEO_DEFAULTS.siteName,
+    url: SITE_URL,
+    description: SEO_DEFAULTS.description,
+    applicationCategory: 'BusinessApplication',
+    offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+    },
+    featureList: [
+        'Multiple CV templates',
+        'PDF export',
+        'PDF import',
+        'Dark mode',
+        'Multilingual support (English, Polish)',
+        'GDPR consent clause',
+        'Auto-save',
+    ],
+    inLanguage: ['en', 'pl'],
+};
+
 export const Route = createRootRoute({
     head: () => ({
         meta: [
@@ -29,30 +53,11 @@ export const Route = createRootRoute({
             },
             { name: 'twitter:description', content: SEO_DEFAULTS.description },
             { name: 'twitter:image', content: OG_DEFAULTS.image },
+        ],
+        headScripts: [
             {
-                'script:ld+json': {
-                    '@context': 'https://schema.org',
-                    '@type': 'WebApplication',
-                    name: SEO_DEFAULTS.siteName,
-                    url: SITE_URL,
-                    description: SEO_DEFAULTS.description,
-                    applicationCategory: 'BusinessApplication',
-                    offers: {
-                        '@type': 'Offer',
-                        price: '0',
-                        priceCurrency: 'USD',
-                    },
-                    featureList: [
-                        'Multiple CV templates',
-                        'PDF export',
-                        'PDF import',
-                        'Dark mode',
-                        'Multilingual support (English, Polish)',
-                        'GDPR consent clause',
-                        'Auto-save',
-                    ],
-                    inLanguage: ['en', 'pl'],
-                },
+                type: 'application/ld+json',
+                children: JSON.stringify(structuredData),
             },
         ],
         links: [


### PR DESCRIPTION
## Summary
- fix PDF preview/export loading in production by updating CSP and cache-related config
- remove preview initialization flicker for long resumes by waiting for layout analysis before mounting the viewer
- fix the preview page hook-order crash and move JSON-LD into the correct TanStack Router head script API
- add explicit scroll-container positioning so Motion parallax hooks stop warning in development